### PR TITLE
Configurable default for CLOUD_NETCONFIG_MANAGE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ common:
 	mkdir -p $(DEST_DEFAULTDIR)
 	install -m 755 common/cloud-netconfig $(DEST_NETCONFDIR)
 	install -m 755 common/cloud-netconfig-cleanup $(DEST_SCRIPTDIR)
-	install -m 755 common/cloud-netconfig-default $(DEST_DEFAULTDIR)/cloud-netconfig
+	install -m 644 common/cloud-netconfig-default $(DEST_DEFAULTDIR)/cloud-netconfig
 	install -m 755 common/cloud-netconfig-hotplug $(DEST_SCRIPTDIR)
 	install -m 644 systemd/cloud-netconfig.service $(DEST_UNITDIR)
 	install -m 644 systemd/cloud-netconfig.timer $(DEST_UNITDIR)

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ UDEVRULESDIR?=$(PREFIX)/lib/udev/rules.d
 NETCONFDIR?=$(SYSCONFDIR)/netconfig.d
 SCRIPTDIR?=$(SYSCONFDIR)/sysconfig/network/scripts
 UNITDIR?=$(PREFIX)/lib/systemd/system
+DEFAULTDIR?=$(SYSCONFDIR)/default
 DESTDIR?=
 DEST_NETCONFDIR=$(DESTDIR)$(NETCONFDIR)
 DEST_UDEVRULESDIR=$(DESTDIR)$(UDEVRULESDIR)
 DEST_SCRIPTDIR=$(DESTDIR)$(SCRIPTDIR)
 DEST_UNITDIR=$(DESTDIR)$(UNITDIR)
+DEST_DEFAULTDIR=$(DESTDIR)$(DEFAULTDIR)
 
 
 verSrc = $(shell cat VERSION)
@@ -33,8 +35,10 @@ common:
 	mkdir -p $(DEST_UDEVRULESDIR)
 	mkdir -p $(DEST_SCRIPTDIR)
 	mkdir -p $(DEST_UNITDIR)
+	mkdir -p $(DEST_DEFAULTDIR)
 	install -m 755 common/cloud-netconfig $(DEST_NETCONFDIR)
 	install -m 755 common/cloud-netconfig-cleanup $(DEST_SCRIPTDIR)
+	install -m 755 common/cloud-netconfig-default $(DEST_DEFAULTDIR)/cloud-netconfig
 	install -m 755 common/cloud-netconfig-hotplug $(DEST_SCRIPTDIR)
 	install -m 644 systemd/cloud-netconfig.service $(DEST_UNITDIR)
 	install -m 644 systemd/cloud-netconfig.timer $(DEST_UNITDIR)

--- a/cloud-netconfig-azure.spec
+++ b/cloud-netconfig-azure.spec
@@ -68,6 +68,7 @@ ln -s /dev/null %{buildroot}/%{_sysconfdir}/udev/rules.d/75-persistent-net-gener
 
 %files
 %defattr(-,root,root)
+%config(noreplace) %{_sysconfdir}/default/cloud-netconfig
 %{_sysconfdir}/netconfig.d/cloud-netconfig
 %{_sysconfdir}/sysconfig/network/scripts/*
 %if 0%{?suse_version} >= 1315

--- a/cloud-netconfig-azure.spec
+++ b/cloud-netconfig-azure.spec
@@ -20,7 +20,7 @@
 Name:           %{base_name}-azure
 Version:        1.4
 Release:        0
-License:        GPL-3.0+
+License:        GPL-3.0-or-later
 Summary:        Network configuration scripts for Microsoft Azure
 Url:            https://github.com/SUSE/Enceladus
 Group:          System/Management
@@ -35,7 +35,7 @@ Requires:       sysconfig
 BuildRequires:  sysconfig-netconfig
 Requires:       sysconfig-netconfig
 %endif
-BuildRequires:  udev
+BuildRequires:  pkgconfig(udev)
 Requires:       udev
 Requires:       curl
 Provides:       cloud-netconfig

--- a/cloud-netconfig-ec2.spec
+++ b/cloud-netconfig-ec2.spec
@@ -68,6 +68,7 @@ ln -s /dev/null %{buildroot}/%{_sysconfdir}/udev/rules.d/75-persistent-net-gener
 
 %files
 %defattr(-,root,root)
+%config(noreplace) %{_sysconfdir}/default/cloud-netconfig
 %{_sysconfdir}/netconfig.d/cloud-netconfig
 %{_sysconfdir}/sysconfig/network/scripts/*
 %if 0%{?suse_version} >= 1315

--- a/cloud-netconfig-ec2.spec
+++ b/cloud-netconfig-ec2.spec
@@ -20,7 +20,7 @@
 Name:           %{base_name}-ec2
 Version:        1.4
 Release:        0
-License:        GPL-3.0+
+License:        GPL-3.0-or-later
 Summary:        Network configuration scripts for Amazon EC2
 Url:            https://github.com/SUSE/Enceladus
 Group:          System/Management
@@ -35,7 +35,7 @@ Requires:       sysconfig
 BuildRequires:  sysconfig-netconfig
 Requires:       sysconfig-netconfig
 %endif
-BuildRequires:  udev
+BuildRequires:  pkgconfig(udev)
 Requires:       udev
 Requires:       curl
 Provides:       cloud-netconfig

--- a/cloud-netconfig.spec
+++ b/cloud-netconfig.spec
@@ -34,7 +34,7 @@ ExclusiveArch:  do-not-build
 Name:           %{base_name}%{flavor_suffix}
 Version:        1.4
 Release:        0
-License:        GPL-3.0+
+License:        GPL-3.0-or-later
 Summary:        Network configuration scripts for %{csp_string}
 Url:            https://github.com/SUSE-Enceladus/cloud-netconfig
 Group:          System/Management
@@ -49,7 +49,7 @@ Requires:       sysconfig
 BuildRequires:  sysconfig-netconfig
 Requires:       sysconfig-netconfig
 %endif
-BuildRequires:  udev
+BuildRequires:  pkgconfig(udev)
 Requires:       udev
 Requires:       curl
 %if 0%{?sles_version} == 11

--- a/cloud-netconfig.spec
+++ b/cloud-netconfig.spec
@@ -89,6 +89,7 @@ ln -s /dev/null %{buildroot}/%{_sysconfdir}/udev/rules.d/75-persistent-net-gener
 
 %files -n %{base_name}%{flavor_suffix}
 %defattr(-,root,root)
+%config(noreplace) %{_sysconfdir}/default/cloud-netconfig
 %{_sysconfdir}/netconfig.d/cloud-netconfig
 %{_sysconfdir}/sysconfig/network/scripts/*
 %if 0%{?suse_version} >= 1315

--- a/common/cloud-netconfig-default
+++ b/common/cloud-netconfig-default
@@ -1,0 +1,2 @@
+# Default value cloud-netconfig should use when creating new ifcfg files
+CLOUD_NETCONFIG_MANAGE="yes"

--- a/common/cloud-netconfig-hotplug
+++ b/common/cloud-netconfig-hotplug
@@ -21,6 +21,9 @@
 test -z "$INTERFACE" && exit 1
 test "$INTERFACE" == "eth0" && exit 0
 
+test -f /etc/default/cloud-netconfig && . /etc/default/cloud-netconfig
+test -z "$CLOUD_NETCONFIG_MANAGE" && CLOUD_NETCONFIG_MANAGE=yes
+
 get_network_service()
 {
     if type -p systemctl >/dev/null ; then
@@ -53,7 +56,7 @@ STARTMODE="hotplug"
 BOOTPROTO="dhcp"
 DHCLIENT_SET_DEFAULT_ROUTE="yes"
 DHCLIENT_ROUTE_PRIORITY="10${INTERFACE#eth}00"
-CLOUD_NETCONFIG_MANAGE="yes"
+CLOUD_NETCONFIG_MANAGE="$CLOUD_NETCONFIG_MANAGE"
 POST_DOWN_SCRIPT="${SCRIPT_PREFIX}cloud-netconfig-cleanup"
 EOF
 }


### PR DESCRIPTION
Hopefully the final PR for this. The copy-routes feature should fix the issue we've seen on k8s nodes, but I guess it's not impossible that there are setups where this still may be insufficient. Giving the admin the possibility to set the default for CLOUD_NETCONFIG_MANAGE to "no" will allow them to just use the automatic setup of new interfaces without cloud-netconfig fiddling with secondary IP addresses and routing policies.