### PR TITLE
Fix ignore proxy for metadata

### DIFF
--- a/azure/functions.cloud-netconfig
+++ b/azure/functions.cloud-netconfig
@@ -19,7 +19,7 @@
 METADATA_BASE_URL="http://169.254.169.254/metadata/instance/network/interface/"
 URL_HDR="Metadata:true"
 URL_APX='?format=text&api-version=2017-04-02'
-CURL="curl -m 3 --noproxy '*' -H $URL_HDR"
+CURL="curl -m 3 --noproxy 169.254.169.254 -H $URL_HDR"
 
 
 # -------------------------------------------------------------------

--- a/ec2/functions.cloud-netconfig
+++ b/ec2/functions.cloud-netconfig
@@ -19,7 +19,7 @@
 API_VERSION="2018-09-24"
 METADATA_URL_BASE="http://169.254.169.254/${API_VERSION}"
 METADATA_URL_IFACE="${METADATA_URL_BASE}/meta-data/network/interfaces/macs"
-CURL="curl -m 3 --noproxy '*'"
+CURL="curl -m 3 --noproxy 169.254.169.254"
 TOKEN_TTL="60"
 declare TOKEN
 


### PR DESCRIPTION
The initial commit that was supposed to ignore proxy settings didn't work due to quoting issues. This PR fixes it by using the IMDS address instead of wildcard with `curl --noproxy`.