### PR TITLE
Moved installs scripts to a FHS conform place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: common help install-azure install-ec2
 PREFIX?=/usr
 SYSCONFDIR?=/etc
+LIBEXECDIR?=/usr/libexec
 UDEVRULESDIR?=$(PREFIX)/lib/udev/rules.d
-NETCONFDIR?=$(SYSCONFDIR)/netconfig.d
-SCRIPTDIR?=$(SYSCONFDIR)/sysconfig/network/scripts
+NETCONFDIR?=$(LIBEXECDIR)/netconfig/netconfig.d
+SCRIPTDIR?=$(LIBEXECDIR)/netconfig/scripts
 UNITDIR?=$(PREFIX)/lib/systemd/system
 DEFAULTDIR?=$(SYSCONFDIR)/default
 DESTDIR?=

--- a/azure/61-cloud-netconfig-hotplug.rules
+++ b/azure/61-cloud-netconfig-hotplug.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="net", KERNEL=="eth*", DRIVERS=="hv_netvsc", RUN+="/etc/sysconfig/network/scripts/cloud-netconfig-hotplug"
+SUBSYSTEM=="net", KERNEL=="eth*", DRIVERS=="hv_netvsc", RUN+="/usr/libexec/netconfig/scripts/cloud-netconfig-hotplug"

--- a/cloud-netconfig.spec
+++ b/cloud-netconfig.spec
@@ -81,6 +81,7 @@ make install%{flavor_suffix} \
   DESTDIR=%{buildroot} \
   PREFIX=%{_usr} \
   SYSCONFDIR=%{_sysconfdir} \
+  LIBEXECDIR=%{_libexecdir} \
   UDEVRULESDIR=%{_udevrulesdir} \
   UNITDIR=%{_unitdir}
 
@@ -93,9 +94,12 @@ ln -s /dev/null %{buildroot}/%{_sysconfdir}/udev/rules.d/75-persistent-net-gener
 
 %files -n %{base_name}%{flavor_suffix}
 %defattr(-,root,root)
+%dir %{_libexecdir}/netconfig
+%dir %{_libexecdir}/netconfig/scripts
+%dir %{_libexecdir}/netconfig/netconfig.d
+%{_libexecdir}/netconfig/scripts/*
+%{_libexecdir}/netconfig/netconfig.d/cloud-netconfig
 %config(noreplace) %{_sysconfdir}/default/cloud-netconfig
-%{_sysconfdir}/netconfig.d/cloud-netconfig
-%{_sysconfdir}/sysconfig/network/scripts/*
 %if 0%{?suse_version} >= 1315
 %{_sysconfdir}/udev/rules.d
 %endif

--- a/common/cloud-netconfig
+++ b/common/cloud-netconfig
@@ -22,9 +22,9 @@ PROGNAME="cloud-netconfig"
 # managed by SuSEconfig when that root is not '/'
 r="$ROOT"
 
-. "$r/etc/sysconfig/network/scripts/functions.netconfig"
+. "$r/usr/libexec/netconfig/scripts/functions.netconfig"
 # for get_ipv4_addresses_from_metadata()
-. "$r/etc/sysconfig/network/scripts/functions.cloud-netconfig"
+. "$r/usr/libexec/netconfig/scripts/functions.cloud-netconfig"
 
 STATEDIR=/var/run/netconfig
 ADDRDIR=/var/run/netconfig/cloud

--- a/common/cloud-netconfig-hotplug
+++ b/common/cloud-netconfig-hotplug
@@ -100,7 +100,7 @@ case "$ACTION" in
     ;;
 
     remove)
-        /etc/sysconfig/network/scripts/cloud-netconfig-cleanup
+        /usr/libexec/netconfig/scripts/cloud-netconfig-cleanup
     ;;
 
 esac

--- a/ec2/51-cloud-netconfig-hotplug.rules
+++ b/ec2/51-cloud-netconfig-hotplug.rules
@@ -1,2 +1,2 @@
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth*", IMPORT{program}="/bin/sleep 1"
-SUBSYSTEM=="net", KERNEL=="eth*", RUN+="/etc/sysconfig/network/scripts/cloud-netconfig-hotplug"
+SUBSYSTEM=="net", KERNEL=="eth*", RUN+="/usr/libexec/netconfig/scripts/cloud-netconfig-hotplug"

--- a/gce/51-cloud-netconfig-hotplug.rules
+++ b/gce/51-cloud-netconfig-hotplug.rules
@@ -1,2 +1,2 @@
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth*", IMPORT{program}="/bin/sleep 1"
-SUBSYSTEM=="net", KERNEL=="eth*", RUN+="/etc/sysconfig/network/scripts/cloud-netconfig-hotplug"
+SUBSYSTEM=="net", KERNEL=="eth*", RUN+="/usr/libexec/netconfig/scripts/cloud-netconfig-hotplug"


### PR DESCRIPTION
Moved:
- /etc/sysconfig/network/scripts -> /usr/libexec/netconfig/scripts
- /etc/netconfig.d  -> /usr/libexec/netconfig/netconfig.d/

This patch depends on PR:
https://github.com/openSUSE/sysconfig/pull/36
which is based on the request:
https://github.com/openSUSE/sysconfig/issues/33

So we will have to wait for this PR at first.