### PR TITLE
Own directory /etc/sysconfig/network

### DIFF
--- a/cloud-netconfig.spec
+++ b/cloud-netconfig.spec
@@ -152,7 +152,7 @@ rm -r %{buildroot}/%{_sysconfdir}/sysconfig
 %endif
 %if %{with_sysconfig} == 1
 %{_netconfigdir}
-%{_sysconfdir}/sysconfig/network/scripts/cloud-netconfig-cleanup
+%{_sysconfdir}/sysconfig/network
 %endif
 %if 0%{?suse_version} >= 1315
 %{_sysconfdir}/udev/rules.d


### PR DESCRIPTION
Add directory /etc/sysconfig/network to package file list to avoid lack of ownership error in case sysconfig is not installed.