### PR TITLE
Installation clean-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,21 +37,15 @@ common:
 	mkdir -p $(DESTDIR)$(SCRIPTDIR)
 	mkdir -p $(DESTDIR)$(UNITDIR)
 	mkdir -p $(DESTDIR)$(DEFAULTDIR)
-	mkdir -p $(DESTDIR)$(NETCONFIGDIR)
-	mkdir -p $(DESTDIR)$(NMDISPATCHDIR)
 	install -m 755 common/cloud-netconfig $(DESTDIR)$(SCRIPTDIR)
 	install -m 755 common/cloud-netconfig-cleanup $(DESTDIR)$(SCRIPTDIR)
 	install -m 644 common/cloud-netconfig-default $(DESTDIR)$(DEFAULTDIR)/cloud-netconfig
 	install -m 755 common/cloud-netconfig-hotplug $(DESTDIR)$(SCRIPTDIR)
-	install -m 755 common/cloud-netconfig-wrapper $(DESTDIR)$(NETCONFIGDIR)/cloud-netconfig
-	install -m 755 common/cloud-netconfig-nm $(DESTDIR)$(NMDISPATCHDIR)/$(NM_DISPATCH_SCRIPT)
 	install -m 644 systemd/cloud-netconfig.service $(DESTDIR)$(UNITDIR)
 	install -m 644 systemd/cloud-netconfig.timer $(DESTDIR)$(UNITDIR)
 	sed -i -r -e "s;SCRIPTDIR=.*;SCRIPTDIR=${SCRIPTDIR};g" $(DESTDIR)$(SCRIPTDIR)/cloud-netconfig
 	sed -i -r -e "s;SCRIPTDIR=.*;SCRIPTDIR=${SCRIPTDIR};g" $(DESTDIR)$(SCRIPTDIR)/cloud-netconfig-hotplug
 	sed -i -r -e "s;DISTCONFDIR=.*;DISTCONFDIR=${DISTCONFDIR};g" $(DESTDIR)$(SCRIPTDIR)/cloud-netconfig-hotplug
-	sed -i -r -e "s;SCRIPTDIR=.*;SCRIPTDIR=${SCRIPTDIR};g" $(DESTDIR)$(NETCONFIGDIR)/cloud-netconfig
-	sed -i -r -e "s;SCRIPTDIR=.*;SCRIPTDIR=${SCRIPTDIR};g" $(DESTDIR)$(NMDISPATCHDIR)/$(NM_DISPATCH_SCRIPT)
 	sed -i -r -e "s;%SCRIPTDIR%;${SCRIPTDIR};g" $(DESTDIR)$(UNITDIR)/cloud-netconfig.service
 
 install-azure: common
@@ -71,6 +65,16 @@ install-gce: common
 	install -m 644 gce/51-cloud-netconfig-hotplug.rules $(DESTDIR)$(UDEVRULESDIR)
 	install -m 755 gce/functions.cloud-netconfig $(DESTDIR)$(SCRIPTDIR)
 	sed -i -e "s;%SCRIPTDIR%;${SCRIPTDIR};g" $(DESTDIR)$(UDEVRULESDIR)/*hotplug.rules
+
+install-netconfig-wrapper:
+	mkdir -p $(DESTDIR)$(NETCONFIGDIR)
+	install -m 755 common/cloud-netconfig-wrapper $(DESTDIR)$(NETCONFIGDIR)/cloud-netconfig
+	sed -i -r -e "s;SCRIPTDIR=.*;SCRIPTDIR=${SCRIPTDIR};g" $(DESTDIR)$(NETCONFIGDIR)/cloud-netconfig
+
+install-nm-dispatcher:
+	mkdir -p $(DESTDIR)$(NMDISPATCHDIR)
+	install -m 755 common/cloud-netconfig-nm $(DESTDIR)$(NMDISPATCHDIR)/$(NM_DISPATCH_SCRIPT)
+	sed -i -r -e "s;SCRIPTDIR=.*;SCRIPTDIR=${SCRIPTDIR};g" $(DESTDIR)$(NMDISPATCHDIR)/$(NM_DISPATCH_SCRIPT)
 
 tarball:
 	@test -n "$(verSrc)"

--- a/cloud-netconfig.spec
+++ b/cloud-netconfig.spec
@@ -1,7 +1,7 @@
 #
-# spec file for package cloud-netconfig
+# spec file
 #
-# Copyright (c) 2024 SUSE Linux GmbH, Nuernberg, Germany.
+# Copyright (c) 2024 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,15 +12,21 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
 %define base_name cloud-netconfig
+%define build_nm_pkg 0
 
 %if "@BUILD_FLAVOR@" == ""
 %define flavor_suffix %nil
 %define csp_string None
+%if 0%{?sle_version} > 150100 || 0%{?suse_version} >= 1600
+%define build_nm_pkg 1
+%else
 ExclusiveArch:  do-not-build
+%endif
 %endif
 %if "@BUILD_FLAVOR@" == "azure"
 %define flavor_suffix -azure
@@ -51,32 +57,20 @@ Version:        1.9
 Release:        0
 License:        GPL-3.0-or-later
 Summary:        Network configuration scripts for %{csp_string}
-Url:            https://github.com/SUSE-Enceladus/cloud-netconfig
+URL:            https://github.com/SUSE-Enceladus/cloud-netconfig
 Group:          System/Management
 Source0:        %{base_name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-%if 0%{?suse_version} == 1110
-BuildRequires:  sysconfig
-Requires:       sysconfig
-%define _udevrulesdir %{_sysconfdir}/udev/rules.d
-%endif
-BuildRequires:  pkgconfig(udev)
 BuildRequires:  systemd-rpm-macros
-%if 0%{?sle_version} > 150100
+BuildRequires:  pkgconfig(udev)
+%if %{build_nm_pkg} == 1
 BuildRequires:  NetworkManager
 %endif
-Requires:       udev
 Requires:       curl
-%if 0%{?sles_version} == 11
-# RPM in SLES 11 does not support self conflict, use otherproviders()
-# workaround
-Provides:       cloud-netconfig
-Conflicts:      otherproviders(cloud-netconfig)
-%else
+Requires:       udev
 Provides:       cloud-netconfig
 Conflicts:      cloud-netconfig
-%endif
 %if 0%{?suse_version} == 1315
 %{?systemd_requires}
 %else
@@ -89,17 +83,16 @@ Conflicts:      cloud-netconfig
 %define _netconfigdir %{_sysconfdir}/netconfig.d
 %endif
 
-
 %description -n %{base_name}%{flavor_suffix}
 This package contains scripts for automatically configuring network interfaces
 in %{csp_string} with full support for hotplug.
 
-%if 0%{?sle_version} > 150100
+%if %{build_nm_pkg} == 1
 %package -n %{base_name}-nm
 Summary:        Network configuration scripts for %{csp_string}
 Group:          System/Management
-Requires:       cloud-netconfig
 Requires:       NetworkManager
+Requires:       cloud-netconfig
 
 %description -n %{base_name}-nm
 Dispatch script for NetworkManager that automatically runs cloud-netconfig.
@@ -111,6 +104,10 @@ Dispatch script for NetworkManager that automatically runs cloud-netconfig.
 %build
 
 %install
+%if %{build_nm_pkg}
+make install-nm-dispatcher \
+  DESTDIR=%{buildroot}
+%else
 make install%{flavor_suffix} \
   DESTDIR=%{buildroot} \
   PREFIX=%{_usr} \
@@ -128,20 +125,19 @@ mkdir -p %{buildroot}/%{_sysconfdir}/udev/rules.d
 ln -s /dev/null %{buildroot}/%{_sysconfdir}/udev/rules.d/75-persistent-net-generator.rules
 %endif
 
+%if %{with_sysconfig} == 1
+make install-netconfig-wrapper \
+  DESTDIR=%{buildroot} \
+  NETCONFIGDIR=%{_netconfigdir}
+
 # install link to cleanup script in /etc/sysconfig/network/scripts to wicked
 # will find it
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig/network/scripts
 ln -s %{_scriptdir}/cloud-netconfig-cleanup %{buildroot}/%{_sysconfdir}/sysconfig/network/scripts/cloud-netconfig-cleanup
-
-%if 0%{?sle_version} <= 150100
-rm -r %{buildroot}/usr/lib/NetworkManager
+%endif
 %endif
 
-%if %{with_sysconfig} == 0
-rm -r %{buildroot}/%{_netconfigdir}
-rm -r %{buildroot}/%{_sysconfdir}/sysconfig
-%endif
-
+%if %{build_nm_pkg} == 0
 %files -n %{base_name}%{flavor_suffix}
 %defattr(-,root,root)
 %{_scriptdir}
@@ -161,8 +157,9 @@ rm -r %{buildroot}/%{_sysconfdir}/sysconfig
 %{_unitdir}/*
 %doc README.md
 %license LICENSE
+%endif
 
-%if 0%{?sle_version} > 150100
+%if %{build_nm_pkg} == 1
 %files -n %{base_name}-nm
 /usr/lib/NetworkManager/dispatcher.d
 %endif


### PR DESCRIPTION
Install NetworkManager dispatcher script on non-SLE platforms.
Make nm-dispatcher and netconfig-wrapper separate install targets for easier handling in spec file.
Build cloud-netconfig-nm as sub package of non-flavor build so it gets only built once.
Remove bits from spec file specific to obsolete platforms.