### PR TITLE
Multiple fixes

### DIFF
--- a/azure/functions.cloud-netconfig
+++ b/azure/functions.cloud-netconfig
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2017 SUSE Linux GmbH
+# Copyright (c) 2017-2024 SUSE Linux GmbH
 #
 # This file is part of cloud-netconfig.
 #
@@ -19,8 +19,8 @@
 METADATA_BASE_URL="http://169.254.169.254/metadata/instance/network/interface/"
 URL_HDR="Metadata:true"
 URL_APX='?format=text&api-version=2017-04-02'
-CURL="curl -m 3 --noproxy 169.254.169.254 -H $URL_HDR"
-
+CURL="curl -m 3 --noproxy 169.254.169.254 --no-progress-meter -H $URL_HDR"
+LOG_CURL="logger -t cloud-netconfig -e"
 
 # -------------------------------------------------------------------
 # look up a meta data item
@@ -28,19 +28,30 @@ CURL="curl -m 3 --noproxy 169.254.169.254 -H $URL_HDR"
 get_from_metadata()
 {
     local url="${METADATA_BASE_URL}${1}${URL_APX}"
-    local result=$($CURL $url 2>/dev/null)
-    local count=0
+    local count=0 result response_file
+    response_file=$(mktemp /tmp/cn-response.XXXXXX) || return 1
+    result=$($CURL -D $response_file $url 2> >($LOG_CURL)) || return 1
 
     while [[ $result == "Too many requests" ]]; do
         count=$((count+1))
         if [[ $count -gt 10 ]]; then
-            return
+            return 1
         fi
         sleep 0.5
-        result=$($CURL $url | tr -d ' \n' 2>/dev/null)
+        result=$($CURL -D $response_file $url 2> >($LOG_CURL)) || return 1
     done
 
-    echo -n $result
+    local http_ver http_code text
+    read http_ver http_code text < $response_file
+    rm $response_file
+    if [[ $http_code == 200 ]]; then
+        echo -n $result
+        return 0
+    else
+        logger -t cloud-netconfig "Error: metadata server returned $http_code"
+        test -n "$result" && logger -t cloud-netconfig "Response: $result"
+        return 1
+    fi
 }
 
 
@@ -54,6 +65,7 @@ get_iface_mac()
     test -z "$if_idx" && return
 
     get_from_metadata "${if_idx}/macAddress"
+    return $?
 }
 
 # -------------------------------------------------------------------
@@ -62,14 +74,15 @@ get_iface_mac()
 #
 get_ipv4_addresses_by_index()
 {
-    local if_idx="$1" count=0 prefixlen="$2"
+    local if_idx="$1" count=0 prefixlen="$2" indices
     test -z "$if_idx" && return
 
-    for idx in `get_from_metadata "${if_idx}/ipv4/ipAddress"` ; do
+    indices=$(get_from_metadata "${if_idx}/ipv4/ipAddress") || return 1
+    for idx in $indices ; do
         [[ $count -ge 1 ]] && echo -n " "
-        get_from_metadata "${if_idx}/ipv4/ipAddress/${idx}privateIpAddress"
+        get_from_metadata "${if_idx}/ipv4/ipAddress/${idx}privateIpAddress" || return 1
         echo -n "/"
-        get_from_metadata "${if_idx}/ipv4/subnet/0/prefix"
+        get_from_metadata "${if_idx}/ipv4/subnet/0/prefix" || return 1
         count=$((count+1))
     done
 }
@@ -79,14 +92,15 @@ get_ipv4_addresses_by_index()
 #
 get_ipv4_addresses_from_metadata()
 {
-    local idx hwaddr="$1"
+    local idx indices hwaddr="$1"
     test -z "$hwaddr" && return 1
 
     local oldopt=$(shopt -p nocasematch)
     shopt -s nocasematch
-    for idx in $(get_from_metadata) ; do
+    indices=$(get_from_metadata) || return 1
+    for idx in $indices ; do
         if [[ "$(get_iface_mac ${idx%/*})" == "${hwaddr//:/}" ]]; then
-            get_ipv4_addresses_by_index ${idx%/*}
+            get_ipv4_addresses_by_index ${idx%/*} || return 1
         fi
     done
     eval "$oldopt"

--- a/common/cloud-netconfig
+++ b/common/cloud-netconfig
@@ -44,7 +44,7 @@ debug()
 warn()
 {
     test $LOGLEVEL -lt 1 && return
-    logger $LOGGER_OPTS -p warn -t "$*"
+    logger $LOGGER_OPTS -p warn "$*"
 }
 
 # -------------------------------------------------------------------
@@ -414,8 +414,13 @@ configure_interface_ipv4()
 
     # get active and configured addresses
     local laddrs=($(get_ipv4_addresses_from_interface $INTERFACE))
-    local raddrs addr
-    for addr in $(get_ipv4_addresses_from_metadata $HWADDR) ; do
+    local raddrs addr addrs
+    addrs=$(get_ipv4_addresses_from_metadata $HWADDR)
+    if [[ $? -ne 0 ]]; then
+        warn "error getting IPv4 addresses from metadata, aborting configuration of $INTERFACE"
+        return
+    fi
+    for addr in $addrs ; do
         # validate whether element looks like an IPv4 address
         if  [[ $addr =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
             raddrs+=($addr)
@@ -449,8 +454,10 @@ configure_interface_ipv4()
             log "removing address $addr from interface $INTERFACE"
             ip -4 addr del $addr dev $INTERFACE
 
-            # drop routing policy rule
-            ip -4 rule del from ${addr%/*}
+            # drop routing policy rules, if any
+            ip -4 rule show from ${addr%/*} | while read rule ; do
+                ip -4 rule del from ${addr%/*} prio ${rule%:*}
+            done
 
             # remove from address log
             remove_addr_from_log $INTERFACE $addr
@@ -466,25 +473,29 @@ configure_interface_ipv4()
     done
 
     local ip_ranges=$(get_ipv4_ranges_from_metadata $HWADDR)
-    local local_route
-    for ipr in $ip_ranges; do
-        local_route=$(ip r show $ipr type local table local)
-        if [[ -z $local_route ]]; then
-            debug "No local route for IP range $ipr, creating one"
-            ip -4 r add local $ipr dev $INTERFACE table local
-            add_addr_to_log $INTERFACE $ipr aliases_
-        fi
-    done
-    # check if cloud-netconfig configured IP aliases were removed
-    local cn_ip_ranges=$(get_cn_assigned_addrs $INTERFACE ranges_)
-    if [[ -n $cn_ip_ranges ]]; then
-        for ipr in $cn_ip_ranges ; do
-            if [[ " $ip_ranges " == *" $ipr "* ]]; then
-                debug "IP range $ipr was removed, dropping local route"
-                ip -4 r del local $ipr dev $INTERFACE table local
-                remove_addr_from_log $INTERFACE $ipr ranges_
+    if [[ $? -eq 0 ]]; then
+        local local_route
+        for ipr in $ip_ranges; do
+            local_route=$(ip r show $ipr type local table local)
+            if [[ -z $local_route ]]; then
+                debug "No local route for IP range $ipr, creating one"
+                ip -4 r add local $ipr dev $INTERFACE table local
+                add_addr_to_log $INTERFACE $ipr aliases_
             fi
         done
+        # check if cloud-netconfig configured IP aliases were removed
+        local cn_ip_ranges=$(get_cn_assigned_addrs $INTERFACE ranges_)
+        if [[ -n $cn_ip_ranges ]]; then
+            for ipr in $cn_ip_ranges ; do
+                if [[ " $ip_ranges " == *" $ipr "* ]]; then
+                    debug "IP range $ipr was removed, dropping local route"
+                    ip -4 r del local $ipr dev $INTERFACE table local
+                    remove_addr_from_log $INTERFACE $ipr ranges_
+                fi
+            done
+        fi
+    else
+        warn "error getting IPv4 ranges from metadata, skipping ranges configuration on $INTERFACE"
     fi
 
     # If we have a single NIC configuration, skip routing policies
@@ -525,26 +536,6 @@ configure_interface_ipv4()
     # copy specific routes from the default routing table
     update_routing_tables -4 $INTERFACE $dest_table $gw_table
 
-    # update routing policies so connections from addresses on
-    # secondary interfaces are routed via those
-    # also include IP rangers
-    #local found prio from ip rest
-    #for addr in ${raddrs[@]} $ip_ranges ; do
-    #    found=0
-    #    while read -r prio from ip rest ; do
-    #        if [[ "${addr%/32}" == "$ip" ]]; then
-    #            found=1
-    #            break
-    #        fi
-    #    done < <(ip -4 rule show)
-    #    if [[ $found == 0 ]]; then
-	  #  debug "creating policy rule for src address ${addr%/32}"
-    #        #priority=$(get_free_priority $LOCAL_TABLE 4)
-    #        ip -4 rule add from ${addr%/32} priority $dest_table lookup $dest_table
-    #        #priority=$(get_free_priority $GW_TABLE 4)
-    #        ip -4 rule add from ${addr%/32} priority $gw_table lookup $gw_table
-    #    fi
-    #done
     local all_addrs=()
     for addr in ${raddrs[@]} ; do
         all_addrs+=("${addr%/*}")
@@ -594,28 +585,6 @@ configure_interface_ipv6()
     update_routing_tables -6 $INTERFACE $dest_table $gw_table
     local laddrs=($(get_ipv6_addresses_from_interface $INTERFACE))
     update_routing_policies -6 $INTERFACE $dest_table $gw_table laddrs
-
-    #local addr laddrs=($(get_ipv6_addresses_from_interface $INTERFACE))
-    #local found prio from ip rest
-    #for addr in ${laddrs[@]} ; do
-    #    found=0
-    #    while read -r prio from ip rest ; do
-    #        if [[ "${addr%/*}" == "$ip" ]]; then
-    #            found=1
-    #            break
-    #        fi
-    #    done < <(ip -6 rule show)
-    #    if [[ $found == 0 ]]; then
-    #        priority=$(get_free_priority $RTABLE 6)
-    #        debug "creating policy rule for address ${addr%/*}"
-    #        ip -6 rule add from ${addr%/*} priority $priority table $RTABLE
-    #    fi
-    #done
-
-    ## create main (w/o default) lookup rule, if necessary
-    #if [[ -z "$(ip -6 rule show prio 30399)" ]]; then
-    #    ip -6 rule add from all table main prio 30399 suppress_prefixlength 0
-    #fi
 }
 
 # -------------------------------------------------------------------

--- a/gce/functions.cloud-netconfig
+++ b/gce/functions.cloud-netconfig
@@ -36,22 +36,21 @@ get_from_metadata()
 #
 get_ipv4_addresses_from_metadata()
 {
-    local hwaddr="$1"
+    local iface status mac if_match addr hwaddr="$1"
     test -z "$hwaddr" && return 1
 
-    local nics=$(get_from_metadata)
-    for idx in $nics ; do
-        local mac=$(get_from_metadata "${idx}mac")
-        if [[ $mac == $hwaddr ]]; then
-            local addr=$(get_from_metadata ${idx}ip)
-            if [[ ${addr} == ${addr%/*} ]]; then
-                addr="${addr}/32"
-            fi
-            echo $addr
-            return 0
-        fi
-    done
-    return 1
+    while read -r iface status mac rest ; do
+         if [[ $mac == $hwaddr ]]; then
+             if_match=$iface
+             break
+         fi
+    done < <(ip -br -o -4 link show)
+    if [[ -n $if_match ]]; then
+        ip -br -4 -o addr show dev $if_match | awk '{ print $3 }'
+    else
+        return 1
+    fi
+    return 0
 }
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
This fixes a couple of things:

- Avoiding erroneous assignment of the DHCP address with a different prefix in GCE (bsc#1219454) by reverting back to simply looking up the local IP address instead of in metadata (GCE does not support secondary IP address atm anyway)
- Potential hang on warning message
- Abort if IPv4 address metadata lookup failed to avoid deleting addresses in error (only properly implemented in Azure atm)
- Skip adding/removing IP range routes (also only fully working in Azure)
- Only delete routing policy rules if they actually exists (avoids error message)

Besides that, it also adds better error handling to the Azure module, so in case meta data lookup failed for some reason skips interface configuration. We had a bug report that showed that cloud-netconfig removed IP addresses in Azure briefly, hinting to an issue with the IMDS, so hopefully the change will help to avoid this. cloud-netconfig previously checked first whether the URL was available and then fetched the data, now it does that in one go to. It also logs errors accessing the meta data, so hopefully the logs will provide more insight in case something like this happens again.

Better error handling and potentially logging should probably be implemented in the EC2 and GCE modules too (although I have not received any reports about issues with accessing IMDS in those).