### PR TITLE
Fix for token test condition

### DIFF
--- a/ec2/functions.cloud-netconfig
+++ b/ec2/functions.cloud-netconfig
@@ -33,9 +33,9 @@ set_metadata_token()
       TOKEN=$($CURL -X PUT "http://169.254.169.254/latest/api/token" \
               -H "X-aws-ec2-metadata-token-ttl-seconds: $TOKEN_TTL" 2>/dev/null)
       # no token, try IPv6
-      test -z "$TOKEN" && TOKEN=$($CURL -X PUT "http://[fd00:ec2::254]/latest/api/token" \
+      if [ -z "$TOKEN" ]; then
+          TOKEN=$($CURL -X PUT "http://[fd00:ec2::254]/latest/api/token" \
               -H "X-aws-ec2-metadata-token-ttl-seconds: $TOKEN_TTL" 2>/dev/null)
-      if [ -n "$TOKEN" ]; then
           METADATA_URL_BASE=${METADATA_URL_BASE6}
           METADATA_URL_IFACE="${METADATA_URL_BASE}/meta-data/network/interfaces/macs"
       fi


### PR DESCRIPTION
This is a fix for the token test condition i.e. -n $TOKEN, which evaluates to true if $TOKEN is set to a non-empty string and results in the IMDS URL being set to the IPv6 endpoint. I also created [bsc#1221202](https://bugzilla.suse.com/show_bug.cgi?id=1221202) for the issue.

This was introduced with via the following commit, https://github.com/SUSE-Enceladus/cloud-netconfig/commit/f6f468fc972ee1600f1c48169bd595556119bd25

Applying the following SUSE patch on SLE 15 SP5 results in not being able to access the IMDS.

- https://www.suse.com/support/update/announcement/2024/suse-ru-20240630-1

> Support IPv6 IMDS endpoint in EC2 (bsc#1218069)

Reproduction steps on SLE 15 SP5:

```
$ cat /etc/os-release
NAME="SLES"
VERSION="15-SP5"
VERSION_ID="15.5"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP5"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp5"
DOCUMENTATION_URL="https://documentation.suse.com/"

$ sudo zypper in -t patch SUSE-SLE-Module-Public-Cloud-15-SP5-2024-630=1
$ sudo netconfig update -f

cloud-netconfig: Cannot access instance metadata, skipping interface configuration for eth0
cloud-netconfig: Cannot access instance metadata, skipping interface configuration for eth1
```

Adding echo for the token, we can see that it's set but the -n $TOKEN results in the IPv6 endpoint still being set despite getting a token via IPv4.

```
set_metadata_token()
{
    if [ -z "$TOKEN" ]; then
      TOKEN=$($CURL -X PUT "http://169.254.169.254/latest/api/token" \
              -H "X-aws-ec2-metadata-token-ttl-seconds: $TOKEN_TTL" 2>/dev/null)
      echo $TOKEN

      # no token, try IPv6
      test -z "$TOKEN" && TOKEN=$($CURL -X PUT "http://[fd00:ec2::254]/latest/api/token" \
              -H "X-aws-ec2-metadata-token-ttl-seconds: $TOKEN_TTL" 2>/dev/null)
      echo $TOKEN

      if [ -n "$TOKEN" ]; then
          METADATA_URL_BASE=${METADATA_URL_BASE6}
          METADATA_URL_IFACE="${METADATA_URL_BASE}/meta-data/network/interfaces/macs"
      fi

      echo $METADATA_URL_BASE;
      echo $METADATA_URL_IFACE;
    fi
}
```
Output:
```
$ sudo netconfig update -f

AQAEABpVoydb1qJMJGXzQH__1qmr41knPZXoD4qehiT9U7AQnAhDEQ==
AQAEABpVoydb1qJMJGXzQH__1qmr41knPZXoD4qehiT9U7AQnAhDEQ==
http://[fd00:ec2::254]/latest
http://[fd00:ec2::254]/latest/meta-data/network/interfaces/macs
```

