### PR TITLE
Use '-s' instead of '--no-progress-meter' for curl

### DIFF
--- a/azure/functions.cloud-netconfig
+++ b/azure/functions.cloud-netconfig
@@ -19,7 +19,7 @@
 METADATA_BASE_URL="http://169.254.169.254/metadata/instance/network/interface/"
 URL_HDR="Metadata:true"
 URL_APX='?format=text&api-version=2017-04-02'
-CURL="curl -m 3 --noproxy 169.254.169.254 --no-progress-meter -H $URL_HDR"
+CURL="curl -m 3 --noproxy 169.254.169.254 -s -H $URL_HDR"
 LOG_CURL="logger -t cloud-netconfig -e"
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
When executing curl, use parameter '-s' instead of '--no-progress-bar' for compatibility with older versions of curl. (bsc#1221757, issue #33)